### PR TITLE
feat: add default openai key for admin and guest

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@
    | WECHAT_${ID}_APPID        | 公众号的开发者 ID(AppID)                   | 将 ${ID} 替换成你自定义的 ID                       |
    | WECHAT_${ID}_TOKEN        | 公众号的令牌(Token)                        | 将 ${ID} 替换成你自定义的 ID                       |
    | WECHAT_${ID}_AES_KEY      | 公众号的消息加解密密钥(EncodingAESKey)     | 将 ${ID} 替换成你自定义的 ID，开启安全模式或兼容模式时才需要 |
-   | WECHAT_ADMIN_USER_ID_LIST | admin 用户名单，多个则以英文逗号分隔           | 可以暂时先不配，等后面知道自己的用户 ID 后再配置   |
+   | WECHAT_ADMIN_USER_ID_LIST | admin 用户名单，多个则以英文逗号分隔       | 可以暂时先不配，等后面知道自己的用户 ID 后再配置   |
+   | WECHAT_ADMIN_OPENAI_KEY   | admin 用户的 OpenAI Key                    | 可选，默认会使用 `WECHAT_GUEST_OPENAI_KEY` |
+   | WECHAT_GUEST_OPENAI_KEY   | 游客的 OpenAI Key                          | 可选，如果不配的话，需要用户通过 /bindKey 命令来手动绑定 Key |
 
 4. 根据域名和自定义的 ID 得出第二步中服务器配置的服务器地址(URL)并进行配置，格式为 `https://${域名}/openai/wechat/${ID}`。如域名为 `xxx.com`，自定义的 ID 为 `id123`，则服务器地址(URL)为 `https://xxx.com/openai/wechat/id123`
 5. 消息加解密方式一般选明文，启用服务器配置，验证接入成功后即可使用

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cf-openai",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cf-openai",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "dependencies": {
         "fast-xml-parser": "^4.1.3"
       },

--- a/src/controller/openai/platform/wechat.ts
+++ b/src/controller/openai/platform/wechat.ts
@@ -97,8 +97,8 @@ export class WeChatHandler extends Base<WeChat> {
   async initCtx() {
     const { platform, appid, userId } = this.platform.ctx
     const isAdmin = WE_CHAT_CONFIG.WECHAT_ADMIN_USER_ID_LIST.includes(userId);
+    const adminOpenAiKey = WE_CHAT_CONFIG.WECHAT_ADMIN_OPENAI_KEY;
     const guestOpenAiKey = WE_CHAT_CONFIG.WECHAT_GUEST_OPENAI_KEY;
-    const adminOpenAiKey = WE_CHAT_CONFIG.WECHAT_ADMIN_OPENAI_KEY || guestOpenAiKey;
     if (isAdmin) {
       this.ctx.role.add(CONST.ROLE.ADMIN)
     }
@@ -120,10 +120,8 @@ export class WeChatHandler extends Base<WeChat> {
       }
     } else if (isAdmin && adminOpenAiKey) {
       this.ctx.apiKey = adminOpenAiKey;
-      await kv.setApiKey(platform, appid, userId, adminOpenAiKey);
     } else if (guestOpenAiKey) {
       this.ctx.apiKey = guestOpenAiKey;
-      await kv.setApiKey(platform, appid, userId, guestOpenAiKey);
     } else {
       this.logger.debug(`${MODULE} 没有 api key`)
       return

--- a/src/platform/wechat.ts
+++ b/src/platform/wechat.ts
@@ -33,6 +33,8 @@ const MODULE = 'src/platform/wechat.ts'
 export const CONFIG: WeChatConfig = {
   // admin 用户名单，设置时以逗号分隔
   WECHAT_ADMIN_USER_ID_LIST: [],
+  WECHAT_ADMIN_OPENAI_KEY: '',
+  WECHAT_GUEST_OPENAI_KEY: '',
   // 处理微信请求的最大毫秒数
   WECHAT_HANDLE_MS_TIME: 13000,
   // 允许访问的 id 列表

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,11 @@ export interface GlobalConfig {
 
 export interface WeChatConfig {
   // admin 用户名单
-  WECHAT_ADMIN_USER_ID_LIST: string[]
+  WECHAT_ADMIN_USER_ID_LIST: string[],
+  // 游客的默认 openai key
+  WECHAT_GUEST_OPENAI_KEY: string,
+  // admin 用户的默认 openai key
+  WECHAT_ADMIN_OPENAI_KEY: string,
   // 处理微信请求的最大毫秒数
   WECHAT_HANDLE_MS_TIME: number
   // 允许访问的 id 列表


### PR DESCRIPTION
添加两个 Worker 变量 `WECHAT_ADMIN_OPENAI_KEY`, `WECHAT_GUEST_OPENAI_KEY` 分别表示管理员和游客的默认的 openai key，方便游客白嫖。

- 这两个变量都是可选的，如果都为空，则走原来的逻辑
- 管理员会优先使用 `WECHAT_ADMIN_OPENAI_KEY`，如果该值为空，则会使用 `WECHAT_GUEST_OPENAI_KEY` 
- 游客只使用  `WECHAT_GUEST_OPENAI_KEY`，如果该值为空，则走原来的逻辑
