### PR TITLE
加入了一些新功能

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cf-openai",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cf-openai",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "fast-xml-parser": "^4.1.3"
       },

--- a/src/controller/openai/config.ts
+++ b/src/controller/openai/config.ts
@@ -8,6 +8,7 @@ export const CONFIG: OpenAiConfig = {
   // OpenAI API key 长度范围
   OPEN_AI_API_KEY_MAX_LEN: 51,
   OPEN_AI_API_KEY_MIN_LEN: 51,
+  OPEN_AI_API_KEY_OCCUPYING_DURATION: 6,
   // OpenAI 的用量地址
   OPEN_AI_USAGE: 'https://api.openai.com/dashboard/billing/usage',
   // OpenAI 的免费用量地址

--- a/src/controller/openai/config.ts
+++ b/src/controller/openai/config.ts
@@ -23,6 +23,8 @@ export const CONFIG: OpenAiConfig = {
   MIN_CHAT_RESPONSE_TOKEN_NUM: 500,
   // 串聊最大历史记录长度
   MAX_HISTORY_LENGTH: 20,
+  // 消息的保存时长，分钟
+  ANSWER_EXPIRES_MINUTES: 3,
   // 全局默认初始化消息，不能使用 Date.now() 获取当前时间，实际会为 0，cloudflare 的限制
   SYSTEM_INIT_MESSAGE: `You are ChatGPT, a large language model trained by OpenAI. Answer as concisely as possible. Knowledge cutoff: 2021-09-01. Current is 2023`,
 }

--- a/src/controller/openai/kv.ts
+++ b/src/controller/openai/kv.ts
@@ -47,6 +47,22 @@ export async function getApiKey(
   )
 }
 
+function getApiKeyOccupiedKey(apiKey: string) {
+  return `openai:apiKeyOccupied:${apiKey}`;
+}
+
+export async function getApiKeyOccupied(apiKey: string) {
+  return get<string>(getApiKeyOccupiedKey(apiKey));
+}
+
+export async function setApiKeyOccupied(apiKey: string, duration: number) {
+  const key = getApiKeyOccupiedKey(apiKey);
+  if (duration <= 0) {
+    return del(key);
+  }
+  return set(key, `${Date.now() + duration * 1000}`, { expirationTtl: Math.max(duration, 60) });
+}
+
 export function getChatTypeKey(
   platform: string,
   appid: string,

--- a/src/controller/openai/kv.ts
+++ b/src/controller/openai/kv.ts
@@ -3,6 +3,7 @@ import { set, get, getWithMetadata, del, setWithStringify } from '../../kv'
 
 import type openai from 'openai'
 import type { ChatType } from './types'
+import { CONFIG } from './config'
 
 const { TIME } = CONST
 
@@ -243,7 +244,7 @@ export async function setPrompt(
   msgId: string
 ) {
   return setWithStringify(getPromptKey(platform, appid, userId, msgId), 1, {
-    expirationTtl: CONST.TIME.ONE_MIN,
+    expirationTtl: CONFIG.ANSWER_EXPIRES_MINUTES * CONST.TIME.ONE_MIN,
   })
 }
 
@@ -274,7 +275,7 @@ export async function setAnswer(
   return set(
     getAnswerKey(platform, appid, userId, msg.msgId),
     msg.content,
-    { expirationTtl: CONST.TIME.ONE_MIN }
+    { expirationTtl: CONFIG.ANSWER_EXPIRES_MINUTES * CONST.TIME.ONE_MIN }
   )
 }
 

--- a/src/controller/openai/platform/base.ts
+++ b/src/controller/openai/platform/base.ts
@@ -104,7 +104,7 @@ export abstract class Base<T extends Platform> {
         return answerRes.data
       }
       // 否则提示用户稍等重试
-      return `正在处理中，请稍后用\n${commandName.retry} ${msgId}\n命令获取回答`
+      return this.getRetryMessage(msgId)
     }
 
     await kv.setPrompt(platform, appid, userId, msgId)
@@ -156,7 +156,7 @@ export abstract class Base<T extends Platform> {
         return lastChatAnswerRes.data.content
       }
       // 否则提示用户稍等重试
-      return `正在处理中，请稍后用\n${commandName.retry} ${msgId}\n命令获取回答`
+      return this.getRetryMessage(msgId)
     }
 
     // 没有 conversationId 则用 reqId 作为 conversationId
@@ -547,6 +547,7 @@ export abstract class Base<T extends Platform> {
     if (!msgId || !msgId.trim()) {
       return genFail('msgId 为空')
     }
+    msgId= msgId.trim().split("\n")[0];
 
     const [promptRes, answerRes] = await Promise.all([
       kv.getPrompt(platform, appid, userId, msgId),
@@ -561,9 +562,7 @@ export abstract class Base<T extends Platform> {
         return genSuccess(answerRes.data)
       }
       // 否则提示用户稍等重试
-      return genSuccess(
-        `正在处理中，请稍后用\n${commandName.retry} ${msgId}\n命令获取回答`
-      )
+      return genSuccess(this.getRetryMessage(msgId))
     }
 
     return genSuccess('该 msgId 无记录，可能已过期')
@@ -657,6 +656,11 @@ export abstract class Base<T extends Platform> {
     this.platform.logger = logger
     this.logger = logger
     return logger
+  }
+
+  protected getRetryMessage(msgId: string): string {
+    // return `正在处理中，请稍后用\n${commandName.retry} ${msgId}\n命令获取回答`;
+    return `${commandName.retry} ${msgId}\n正在处理中，请稍后用使用该命令获取回答`;
   }
 }
 

--- a/src/controller/openai/platform/base.ts
+++ b/src/controller/openai/platform/base.ts
@@ -424,7 +424,7 @@ export abstract class Base<T extends Platform> {
       fn: this.createNewChat.bind(this),
     },
     [commandName.retry]: {
-      description: '根据 msgId 获取对于回答，回答只会保留 1 分钟',
+      description: '根据 msgId 获取对于回答，回答只会保留 3 分钟',
       roles: [CONST.ROLE.USER],
       fn: this.retry.bind(this),
     },

--- a/src/controller/openai/platform/base.ts
+++ b/src/controller/openai/platform/base.ts
@@ -10,7 +10,7 @@ import { CONST, CONFIG as GLOBAL_CONFIG } from '../../../global'
 import { CONFIG } from '../config'
 import { OpenAiClient } from '../openAiClient'
 import * as kv from '../kv'
-import { estimateTokenCount, getApiKeyWithMask } from '../utils'
+import { estimateTokenCount, getApiKeyWithMask, getWeChatOpenIdWithMask } from '../utils'
 import { platformMap } from '../../../platform'
 
 import type openai from 'openai'
@@ -599,7 +599,7 @@ export abstract class Base<T extends Platform> {
       '当前系统信息如下: ',
       `⭐OpenAI 模型: ${CONFIG.CHAT_MODEL}`,
       `⭐OpenAI api key: ${getApiKeyWithMask(apiKey)}`,
-      `当前用户: ${userId}`,
+      `当前用户: ${getWeChatOpenIdWithMask(userId)}`,
     ]
 
     if (GLOBAL_CONFIG.DEBUG_MODE) {

--- a/src/controller/openai/platform/wechat.ts
+++ b/src/controller/openai/platform/wechat.ts
@@ -22,7 +22,7 @@ export class WeChatHandler extends Base<WeChat> {
           this.ctx.chatType === '单聊' ||
           !this.platform.ctx.recvMsg.MsgId
           ? '服务异常，请稍后重试'
-          : `正在处理中，请稍后用\n${commandName.retry} ${this.platform.ctx.recvMsg.MsgId}\n命令获取回答`
+          : this.getRetryMessage(this.platform.ctx.recvMsg.MsgId)
       return this.genWeChatTextXmlResponse(msg)
     })
   }

--- a/src/controller/openai/platform/wechat.ts
+++ b/src/controller/openai/platform/wechat.ts
@@ -19,8 +19,8 @@ export class WeChatHandler extends Base<WeChat> {
     return this.platform.handleRequest(this.handleRecvMsg.bind(this), () => {
       const msg =
         !this.ctx.isRequestOpenAi ||
-        this.ctx.chatType === '单聊' ||
-        !this.platform.ctx.recvMsg.MsgId
+          this.ctx.chatType === '单聊' ||
+          !this.platform.ctx.recvMsg.MsgId
           ? '服务异常，请稍后重试'
           : `正在处理中，请稍后用\n${commandName.retry} ${this.platform.ctx.recvMsg.MsgId}\n命令获取回答`
       return this.genWeChatTextXmlResponse(msg)

--- a/src/controller/openai/utils.ts
+++ b/src/controller/openai/utils.ts
@@ -4,6 +4,10 @@ export function getApiKeyWithMask(apiKey: string) {
   return `${apiKey.slice(0, 6)}****${apiKey.slice(apiKey.length - 4)}`
 }
 
+export function getWeChatOpenIdWithMask(text: string): string {
+  return `${text.slice(0, 6)}****${text.slice(text.length - 4)}`
+}
+
 /**
  * @see https://platform.openai.com/tokenizer
  * 估算字符串的 token 数量

--- a/src/global.ts
+++ b/src/global.ts
@@ -32,7 +32,7 @@ export const CONST = {
 
 export const CONFIG: GlobalConfig = {
   // 调试模式
-  DEBUG_MODE: false,
+  DEBUG_MODE: true,
   // echo 模式
   ECHO_MODE: false,
   // 告警地址

--- a/src/global.ts
+++ b/src/global.ts
@@ -32,7 +32,7 @@ export const CONST = {
 
 export const CONFIG: GlobalConfig = {
   // 调试模式
-  DEBUG_MODE: true,
+  DEBUG_MODE: false,
   // echo 模式
   ECHO_MODE: false,
   // 告警地址

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export interface OpenAiConfig {
   // OpenAI API key 长度 范围
   OPEN_AI_API_KEY_MIN_LEN: number
   OPEN_AI_API_KEY_MAX_LEN: number
+  OPEN_AI_API_KEY_OCCUPYING_DURATION: number,
   // OpenAI 的用量地址
   OPEN_AI_USAGE: string
   // OpenAI 的免费用量地址

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,8 @@ export interface OpenAiConfig {
   MIN_CHAT_RESPONSE_TOKEN_NUM: number
   // 串聊最大历史记录长度
   MAX_HISTORY_LENGTH: number
+  // 消息的保存时长，分钟
+  ANSWER_EXPIRES_MINUTES: number
   // 全局默认初始化消息
   SYSTEM_INIT_MESSAGE: string
 }


### PR DESCRIPTION
1. 对 openai 的 key 进行限流，默认的请求间隔为 6 秒，见 `getApiKeyOccupied` 和 `setApiKeyOccupied` 方法
2. 将 `/retry` 命令的缓存时间延长到了 3 分钟，之前的 1 分钟太短了，容易出现一直获取不到消息
3. 添加 `..` 和 `。。` 命令，用于获取最后的延迟的回答，类似于 `/retry msgId`，但使用起来更简单